### PR TITLE
Implement club and user registration flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,67 @@
-# proyecto_cronodep
-Prototipo_Cronodep
-# 🏋️‍♂️ Cronodep
+# CronoDep MVC
 
-Sistema SaaS para la gestión eficiente de clubes deportivos.  
-Permite controlar entrenadores, deportistas, asistencias y pagos desde un entorno personalizado y escalable.
+Este repositorio contiene la estructura base del proyecto **CronoDep** implementado en PHP puro bajo el patrón **Modelo-Vista-Controlador (MVC)**, con frontend en HTML, CSS y JavaScript y conexión a la base de datos MySQL/MariaDB provista.
+
+## 📁 Estructura principal
+
+```
+cronoportes/
+├── app/
+│   ├── config/        # Configuración general (BD y ajustes de la app)
+│   ├── controllers/   # Controladores que orquestan la lógica de negocio
+│   ├── models/        # Modelos que interactúan con la base de datos
+│   └── views/         # Vistas HTML reutilizando un layout principal
+├── core/              # Router y utilidades del núcleo MVC
+├── database/          # Scripts SQL iniciales (cronodep.sql)
+├── public/            # Punto de entrada (index.php) y recursos estáticos
+└── routes/            # Definición de rutas HTTP disponibles
+```
+
+## ⚙️ Requisitos previos
+
+- PHP 8.1 o superior con extensiones `pdo` y `pdo_mysql` habilitadas.
+- Servidor web configurado para apuntar a `cronoportes/public` como raíz del documento (por ejemplo Apache o Nginx).
+- MySQL o MariaDB para ejecutar el script `database/cronodep.sql`.
+
+## 🚀 Puesta en marcha
+
+1. Clona el repositorio y navega a la carpeta del proyecto.
+2. Importa la base de datos ejecutando:
+   ```bash
+   mysql -u <usuario> -p < database/cronodep.sql
+   ```
+3. Copia `cronoportes/app/config/config.php` y ajusta las credenciales de la base de datos si es necesario.
+4. Configura el host virtual de tu servidor para que el documento raíz sea `cronoportes/public`.
+5. Accede en el navegador a la URL configurada (por defecto `http://localhost/`).
+
+## 🌐 Rutas incluidas
+
+| Ruta              | Controlador / Acción          | Descripción                              |
+|-------------------|-------------------------------|------------------------------------------|
+| `/`               | `HomeController@index`        | Panel con totales y usuarios recientes. |
+| `/usuarios`       | `UsuarioController@index`     | Listado general de usuarios.            |
+| `/usuarios/crear` | `UsuarioController@create`    | Formulario para registrar un usuario.   |
+| `/usuarios/{id}`  | `UsuarioController@show`      | Detalle de un usuario puntual.          |
+| `/clubs`          | `ClubController@index`        | Listado general de clubs.               |
+| `/clubs/crear`    | `ClubController@create`       | Formulario para registrar un club.      |
+
+## 🗄️ Conexión a la base de datos
+
+El archivo `database/cronodep.sql` contiene exactamente la estructura entregada para el SaaS, con tablas de clubs, usuarios, entrenamientos, pagos y relaciones. El `Model` base inicializa una conexión PDO reutilizable que aprovechan los modelos específicos (`Club` y `Usuario`).
+
+## 🎨 Frontend
+
+- Layout responsive basado en CSS puro (`public/css/styles.css`).
+- Interacciones mínimas con JavaScript (`public/js/app.js`) para resaltar la ruta activa.
+- Las vistas se renderizan mediante el layout principal y reciben los datos desde los controladores.
+
+## ➕ Próximos pasos sugeridos
+
+- Añadir controladores y modelos adicionales para entrenamientos, pagos y reportes.
+- Implementar formularios de autenticación y gestión de sesiones.
+- Incorporar validaciones y manejo de errores más detallado.
+- Crear seeds o datos de ejemplo para acelerar las pruebas iniciales.
 
 ---
 
-## 🔐 Modalidad SaaS
-
-Cada club posee:
-- Acceso privado
-- Panel personalizado
-- Reportes e indicadores propios
-- Control independiente de deportistas e instructores
-
----
-
-## 🚀 Funcionalidades Principales
-
-- [x] Administración de usuarios
-- [x] Paneles personalizados por club
-- [x] Control de asistencias por QR
-- [x] Reportes dinámicos en PDF
-- [x] Estadísticas por disciplina
-
----
-
-## 📈 Próximas funcionalidades
-
-- Integración con QR para seguimiento de asistencias
-- Generación de reportes en PDF
-- Estadísticas comparativas por disciplina
-- Sistema de notificaciones para vencimientos de pagos
-
----
-
-## 🛠️ Tecnologías Utilizadas
-
-| Categoría       | Herramienta / Lenguaje             |
-|-----------------|------------------------------------|
-| Backend         | PHP, Python                        |
-| Frontend        | React, HTML, CSS, JavaScript       |
-| Base de datos   | MariaDB, SQL Server                |
-| Infraestructura | Google Cloud, IAM, Compute Engine  |
-| Otros           | GitHub, Postman, FPDF              |
-
----
-
-## 📐 Guía de Estilos Visuales (por completar)
-
-> Esta sección será completada más adelante con los valores específicos.
-
-| Elemento UI     | Fuente       | Tamaño | Color (hex) | Fondo       |
-|-----------------|--------------|--------|-------------|-------------|
-| Título Principal| _Por definir_| _24px_ | _#1E90FF_   | _Transparente_|
-| Texto General   | _Por definir_| _16px_ | _#333333_   | _#FFFFFF_   |
-| Botones         | _Por definir_| _14px_ | _#FFFFFF_   | _#FF5733_   |
-| Enlaces         | _Por definir_| _14px_ | _#2980B9_   | _N/A_       |
-
-_Ejemplo embebido de estilo HTML dentro del README:_
-
-```html
-<p style="font-size:18px; color:#FF5733;">Texto con estilo personalizado.</p>
+Con esta base puedes continuar evolucionando CronoDep siguiendo el patrón MVC y sin dependencias externas como Composer.

--- a/cronoportes/app/Middleware/AuthMiddleware.php
+++ b/cronoportes/app/Middleware/AuthMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+namespace App\Middleware;
+
+class AuthMiddleware
+{
+    public static function handle(array $roles, callable $next): callable
+    {
+        return function (...$params) use ($roles, $next) {
+            if (!isset($_SESSION['usuario'])) {
+                header('Location: ' . route('/login'));
+                exit;
+            }
+
+            if ($roles && !in_array($_SESSION['rol'] ?? null, $roles, true)) {
+                http_response_code(403);
+                echo 'No tienes permiso para acceder a esta sección.';
+                return;
+            }
+
+            return $next(...$params);
+        };
+    }
+
+    public static function requireAuth(callable $next): callable
+    {
+        return self::handle([], $next);
+    }
+}

--- a/cronoportes/app/config/config.php
+++ b/cronoportes/app/config/config.php
@@ -1,0 +1,15 @@
+<?php
+return [
+    'db' => [
+        'host' => 'localhost',
+        'port' => 3306,
+        'database' => 'cronodep',
+        'username' => 'root',
+        'password' => '',
+        'charset' => 'utf8mb4',
+    ],
+    'app' => [
+        'base_url' => '/',
+        'name' => 'CronoDep',
+    ],
+];

--- a/cronoportes/app/controllers/AuthController.php
+++ b/cronoportes/app/controllers/AuthController.php
@@ -1,0 +1,236 @@
+<?php
+namespace App\Controllers;
+
+use App\Models\Club;
+use App\Models\Usuario;
+use PDOException;
+
+class AuthController extends Controller
+{
+    public function login(): void
+    {
+        if (isset($_SESSION['usuario'])) {
+            $this->redirect($this->redirectRoute($_SESSION['rol'] ?? ''));
+        }
+
+        $clubsRegistrados = Club::countAll();
+        if ($clubsRegistrados === 0) {
+            $this->redirect('/register-club');
+        }
+
+        $this->view('auth/login', [
+            'data' => ['correo' => '', 'clubs_registrados' => $clubsRegistrados],
+            'errors' => [],
+        ]);
+    }
+
+    public function auth(): void
+    {
+        $correo = trim($_POST['correo'] ?? '');
+        $clave = $_POST['clave'] ?? '';
+
+        $errors = [];
+        if ($correo === '' || !filter_var($correo, FILTER_VALIDATE_EMAIL)) {
+            $errors['correo'] = 'Ingresa un correo válido.';
+        }
+
+        if ($clave === '') {
+            $errors['clave'] = 'Ingresa tu contraseña.';
+        }
+
+        if ($errors) {
+            $this->view('auth/login', [
+                'data' => ['correo' => $correo, 'clubs_registrados' => Club::countAll()],
+                'errors' => $errors,
+            ]);
+            return;
+        }
+
+        if (Club::countAll() === 0) {
+            $this->redirect('/register-club');
+        }
+
+        $usuario = Usuario::findByCorreo($correo);
+        if (!$usuario || !password_verify($clave, $usuario['clave'])) {
+            $this->view('auth/login', [
+                'data' => ['correo' => $correo, 'clubs_registrados' => Club::countAll()],
+                'errors' => ['general' => 'Credenciales incorrectas.'],
+            ]);
+            return;
+        }
+
+        $_SESSION['usuario'] = [
+            'id' => $usuario['id_usuario'],
+            'nombre' => $usuario['nombres'] . ' ' . $usuario['apellidos'],
+            'correo' => $usuario['correo'],
+            'id_club' => $usuario['id_club'],
+        ];
+        $_SESSION['rol'] = $usuario['rol'];
+
+        $this->redirect($this->redirectRoute($usuario['rol']));
+    }
+
+    public function logout(): void
+    {
+        $_SESSION = [];
+        if (ini_get('session.use_cookies')) {
+            $params = session_get_cookie_params();
+            setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+        }
+        session_destroy();
+
+        $this->redirect('/login');
+    }
+
+    public function registerClub(): void
+    {
+        if (isset($_SESSION['usuario'])) {
+            $this->redirect($this->redirectRoute($_SESSION['rol'] ?? ''));
+        }
+
+        if (Club::countAll() > 0) {
+            $this->redirect('/login');
+        }
+
+        $this->view('auth/register_club', [
+            'data' => $this->defaultClubData(),
+            'errors' => [],
+        ]);
+    }
+
+    public function storeClub(): void
+    {
+        if (isset($_SESSION['usuario'])) {
+            $this->redirect($this->redirectRoute($_SESSION['rol'] ?? ''));
+        }
+
+        if (Club::countAll() > 0) {
+            $this->redirect('/login');
+        }
+
+        $input = [
+            'nombre_club' => trim($_POST['nombre_club'] ?? ''),
+            'correo_contacto' => trim($_POST['correo_contacto'] ?? ''),
+            'telefono_contacto' => trim($_POST['telefono_contacto'] ?? ''),
+            'direccion' => trim($_POST['direccion'] ?? ''),
+            'documento_operador' => trim($_POST['documento_operador'] ?? ''),
+            'nombres' => trim($_POST['nombres'] ?? ''),
+            'apellidos' => trim($_POST['apellidos'] ?? ''),
+            'documento' => trim($_POST['documento'] ?? ''),
+            'correo' => trim($_POST['correo'] ?? ''),
+            'clave' => $_POST['clave'] ?? '',
+            'confirmacion' => $_POST['confirmacion'] ?? '',
+        ];
+
+        $errors = [];
+
+        if ($input['nombre_club'] === '') {
+            $errors['nombre_club'] = 'El nombre del club es obligatorio.';
+        }
+
+        if ($input['correo_contacto'] !== '' && !filter_var($input['correo_contacto'], FILTER_VALIDATE_EMAIL)) {
+            $errors['correo_contacto'] = 'Ingresa un correo de contacto válido.';
+        }
+
+        if ($input['nombres'] === '') {
+            $errors['nombres'] = 'Ingresa los nombres del responsable.';
+        }
+
+        if ($input['apellidos'] === '') {
+            $errors['apellidos'] = 'Ingresa los apellidos del responsable.';
+        }
+
+        if ($input['documento'] === '') {
+            $errors['documento'] = 'El documento del responsable es obligatorio.';
+        }
+
+        if ($input['correo'] === '' || !filter_var($input['correo'], FILTER_VALIDATE_EMAIL)) {
+            $errors['correo'] = 'Ingresa un correo de acceso válido.';
+        }
+
+        if ($input['clave'] === '') {
+            $errors['clave'] = 'Ingresa una contraseña.';
+        } elseif ($input['clave'] !== $input['confirmacion']) {
+            $errors['confirmacion'] = 'Las contraseñas no coinciden.';
+        }
+
+        if ($errors) {
+            $this->view('auth/register_club', [
+                'data' => array_merge($this->defaultClubData(), $input),
+                'errors' => $errors,
+            ]);
+            return;
+        }
+
+        try {
+            $clubId = Club::create([
+                'nombre_club' => $input['nombre_club'],
+                'correo_contacto' => $input['correo_contacto'] ?: null,
+                'telefono_contacto' => $input['telefono_contacto'] ?: null,
+                'direccion' => $input['direccion'] ?: null,
+                'estado' => 'activo',
+                'documento_operador' => $input['documento_operador'] ?: null,
+            ]);
+
+            $usuarioId = Usuario::create([
+                'id_club' => $clubId,
+                'nombres' => $input['nombres'],
+                'apellidos' => $input['apellidos'],
+                'tipo_documento' => null,
+                'documento' => $input['documento'],
+                'correo' => $input['correo'],
+                'clave' => password_hash($input['clave'], PASSWORD_BCRYPT),
+                'rol' => 'superadmin',
+                'fecha_nacimiento' => null,
+                'tipo_sangre' => null,
+                'celular' => null,
+                'estado' => 'activo',
+                'documento_operador' => $input['documento_operador'] ?: null,
+            ]);
+        } catch (PDOException $e) {
+            if (isset($clubId)) {
+                Club::deleteById((int) $clubId);
+            }
+            $this->view('auth/register_club', [
+                'data' => array_merge($this->defaultClubData(), $input),
+                'errors' => ['general' => 'No fue posible registrar el club inicial. Intenta nuevamente.'],
+            ]);
+            return;
+        }
+
+        $_SESSION['usuario'] = [
+            'id' => $usuarioId,
+            'nombre' => $input['nombres'] . ' ' . $input['apellidos'],
+            'correo' => $input['correo'],
+            'id_club' => $clubId,
+        ];
+        $_SESSION['rol'] = 'superadmin';
+
+        $this->redirect($this->redirectRoute('superadmin'));
+    }
+
+    private function defaultClubData(): array
+    {
+        return [
+            'nombre_club' => '',
+            'correo_contacto' => '',
+            'telefono_contacto' => '',
+            'direccion' => '',
+            'documento_operador' => '',
+            'nombres' => '',
+            'apellidos' => '',
+            'documento' => '',
+            'correo' => '',
+            'clave' => '',
+            'confirmacion' => '',
+        ];
+    }
+
+    private function redirectRoute(string $rol): string
+    {
+        return match ($rol) {
+            'superadmin', 'admin', 'instructor', 'tesorero', 'acudiente', 'deportista' => '/dashboard',
+            default => '/',
+        };
+    }
+}

--- a/cronoportes/app/controllers/ClubController.php
+++ b/cronoportes/app/controllers/ClubController.php
@@ -1,0 +1,89 @@
+<?php
+namespace App\Controllers;
+
+use App\Models\Club;
+use PDOException;
+
+class ClubController extends Controller
+{
+    public function index(): void
+    {
+        $status = filter_input(INPUT_GET, 'status', FILTER_SANITIZE_SPECIAL_CHARS);
+        $message = $status === 'created' ? 'Club registrado correctamente.' : null;
+
+        $this->view('clubs/index', [
+            'clubs' => Club::all(),
+            'message' => $message,
+        ]);
+    }
+
+    public function create(): void
+    {
+        $this->view('clubs/create', [
+            'data' => [
+                'nombre_club' => '',
+                'correo_contacto' => '',
+                'telefono_contacto' => '',
+                'direccion' => '',
+                'estado' => 'activo',
+                'documento_operador' => '',
+            ],
+            'errors' => [],
+        ]);
+    }
+
+    public function store(): void
+    {
+        $input = [
+            'nombre_club' => trim($_POST['nombre_club'] ?? ''),
+            'correo_contacto' => trim($_POST['correo_contacto'] ?? ''),
+            'telefono_contacto' => trim($_POST['telefono_contacto'] ?? ''),
+            'direccion' => trim($_POST['direccion'] ?? ''),
+            'estado' => trim($_POST['estado'] ?? 'activo'),
+            'documento_operador' => trim($_POST['documento_operador'] ?? ''),
+        ];
+
+        $errors = [];
+
+        if ($input['nombre_club'] === '') {
+            $errors['nombre_club'] = 'El nombre del club es obligatorio.';
+        }
+
+        if ($input['correo_contacto'] !== '' && !filter_var($input['correo_contacto'], FILTER_VALIDATE_EMAIL)) {
+            $errors['correo_contacto'] = 'Ingresa un correo electrónico válido.';
+        }
+
+        if ($input['estado'] === '' || !in_array($input['estado'], ['activo', 'inactivo'], true)) {
+            $input['estado'] = 'activo';
+        }
+
+        if ($errors) {
+            $this->view('clubs/create', [
+                'data' => $input,
+                'errors' => $errors,
+            ]);
+            return;
+        }
+
+        $payload = [
+            'nombre_club' => $input['nombre_club'],
+            'correo_contacto' => $input['correo_contacto'] ?: null,
+            'telefono_contacto' => $input['telefono_contacto'] ?: null,
+            'direccion' => $input['direccion'] ?: null,
+            'estado' => $input['estado'],
+            'documento_operador' => $input['documento_operador'] ?: null,
+        ];
+
+        try {
+            Club::create($payload);
+        } catch (PDOException $e) {
+            $this->view('clubs/create', [
+                'data' => $input,
+                'errors' => ['general' => 'No fue posible registrar el club. Verifica la información e intenta nuevamente.'],
+            ]);
+            return;
+        }
+
+        $this->redirect('/clubs', ['status' => 'created']);
+    }
+}

--- a/cronoportes/app/controllers/Controller.php
+++ b/cronoportes/app/controllers/Controller.php
@@ -1,0 +1,48 @@
+<?php
+namespace App\Controllers;
+
+class Controller
+{
+    protected function view(string $template, array $data = []): void
+    {
+        extract($data);
+        $contentFile = __DIR__ . '/../views/' . $template . '.php';
+        if (!file_exists($contentFile)) {
+            http_response_code(404);
+            echo 'Vista no encontrada';
+            return;
+        }
+
+        include __DIR__ . '/../views/layouts/main.php';
+    }
+
+    protected function redirect(string $path, array $query = []): void
+    {
+        $url = $this->url($path, $query);
+        header('Location: ' . $url);
+        exit;
+    }
+
+    protected function url(string $path, array $query = []): string
+    {
+        $normalized = $this->normalizePath($path);
+        $baseUrl = $GLOBALS['baseUrl'] ?? '/';
+        $url = ($baseUrl === '/' || $baseUrl === '') ? $normalized : rtrim($baseUrl, '/') . $normalized;
+
+        if (!empty($query)) {
+            $url .= (str_contains($url, '?') ? '&' : '?') . http_build_query($query);
+        }
+
+        return $url;
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $trimmed = trim($path);
+        if ($trimmed === '' || $trimmed === '/') {
+            return '/';
+        }
+
+        return '/' . ltrim($trimmed, '/');
+    }
+}

--- a/cronoportes/app/controllers/Controller.php
+++ b/cronoportes/app/controllers/Controller.php
@@ -13,6 +13,14 @@ class Controller
             return;
         }
 
+        ob_start();
+        include $contentFile;
+        $content = ob_get_clean();
+
+        if (!isset($title)) {
+            $title = $titulo ?? ($data['title'] ?? null);
+        }
+
         include __DIR__ . '/../views/layouts/main.php';
     }
 

--- a/cronoportes/app/controllers/HomeController.php
+++ b/cronoportes/app/controllers/HomeController.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\Controllers;
+
+use App\Models\Club;
+use App\Models\Usuario;
+
+class HomeController extends Controller
+{
+    public function index(): void
+    {
+        $usuarios = Usuario::all();
+        $clubs = Club::all();
+
+        $this->view('home/index', [
+            'usuarios' => $usuarios,
+            'clubs' => $clubs,
+        ]);
+    }
+}

--- a/cronoportes/app/controllers/HomeController.php
+++ b/cronoportes/app/controllers/HomeController.php
@@ -8,12 +8,39 @@ class HomeController extends Controller
 {
     public function index(): void
     {
-        $usuarios = Usuario::all();
-        $clubs = Club::all();
-
         $this->view('home/index', [
-            'usuarios' => $usuarios,
-            'clubs' => $clubs,
+            'clubsRegistrados' => Club::countAll(),
         ]);
+    }
+
+    public function dashboard(): void
+    {
+        if (!isset($_SESSION['usuario'])) {
+            $this->redirect('/login');
+        }
+
+        $rol = $_SESSION['rol'] ?? '';
+        $view = $this->dashboardView($rol);
+
+        $data = [
+            'usuario' => $_SESSION['usuario'],
+            'rol' => $rol,
+        ];
+
+        if (in_array($rol, ['superadmin', 'admin'], true)) {
+            $data['usuarios'] = Usuario::all();
+            $data['clubs'] = Club::all();
+        }
+
+        $this->view($view, $data);
+    }
+
+    private function dashboardView(string $rol): string
+    {
+        return match ($rol) {
+            'superadmin' => 'dashboard/superadmin',
+            'admin' => 'dashboard/admin',
+            default => 'dashboard/deportista',
+        };
     }
 }

--- a/cronoportes/app/controllers/UsuarioController.php
+++ b/cronoportes/app/controllers/UsuarioController.php
@@ -1,0 +1,160 @@
+<?php
+namespace App\Controllers;
+
+use App\Models\Club;
+use App\Models\Usuario;
+use PDOException;
+
+class UsuarioController extends Controller
+{
+    public function index(): void
+    {
+        $status = filter_input(INPUT_GET, 'status', FILTER_SANITIZE_SPECIAL_CHARS);
+        $message = $status === 'created' ? 'Usuario registrado correctamente.' : null;
+
+        $this->view('usuarios/index', [
+            'usuarios' => Usuario::all(),
+            'message' => $message,
+        ]);
+    }
+
+    public function show(int $id): void
+    {
+        $usuario = Usuario::find($id);
+        if (!$usuario) {
+            http_response_code(404);
+            echo 'Usuario no encontrado';
+            return;
+        }
+
+        $this->view('usuarios/show', ['usuario' => $usuario]);
+    }
+
+    public function create(): void
+    {
+        $this->view('usuarios/create', [
+            'data' => $this->defaultData(),
+            'errors' => [],
+            'roles' => Usuario::roles(),
+            'clubs' => Club::options(),
+        ]);
+    }
+
+    public function store(): void
+    {
+        $input = [
+            'id_club' => $_POST['id_club'] ?? null,
+            'nombres' => trim($_POST['nombres'] ?? ''),
+            'apellidos' => trim($_POST['apellidos'] ?? ''),
+            'tipo_documento' => trim($_POST['tipo_documento'] ?? ''),
+            'documento' => trim($_POST['documento'] ?? ''),
+            'correo' => trim($_POST['correo'] ?? ''),
+            'clave' => $_POST['clave'] ?? '',
+            'rol' => trim($_POST['rol'] ?? ''),
+            'fecha_nacimiento' => trim($_POST['fecha_nacimiento'] ?? ''),
+            'tipo_sangre' => trim($_POST['tipo_sangre'] ?? ''),
+            'celular' => trim($_POST['celular'] ?? ''),
+            'estado' => trim($_POST['estado'] ?? 'activo'),
+            'documento_operador' => trim($_POST['documento_operador'] ?? ''),
+        ];
+
+        $errors = [];
+        $roles = Usuario::roles();
+
+        $clubId = filter_var($input['id_club'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) ?: null;
+
+        if ($input['nombres'] === '') {
+            $errors['nombres'] = 'Los nombres son obligatorios.';
+        }
+
+        if ($input['apellidos'] === '') {
+            $errors['apellidos'] = 'Los apellidos son obligatorios.';
+        }
+
+        if ($input['documento'] === '') {
+            $errors['documento'] = 'El documento es obligatorio.';
+        }
+
+        if ($input['correo'] === '') {
+            $errors['correo'] = 'El correo es obligatorio.';
+        } elseif (!filter_var($input['correo'], FILTER_VALIDATE_EMAIL)) {
+            $errors['correo'] = 'Ingresa un correo válido.';
+        }
+
+        if ($input['clave'] === '') {
+            $errors['clave'] = 'La clave es obligatoria.';
+        }
+
+        if (!in_array($input['rol'], $roles, true)) {
+            $errors['rol'] = 'Selecciona un rol válido.';
+        }
+
+        if ($input['estado'] === '' || !in_array($input['estado'], ['activo', 'inactivo'], true)) {
+            $input['estado'] = 'activo';
+        }
+
+        if ($input['fecha_nacimiento'] !== '' && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $input['fecha_nacimiento'])) {
+            $errors['fecha_nacimiento'] = 'La fecha debe tener el formato AAAA-MM-DD.';
+        }
+
+        if ($errors) {
+            $input['id_club'] = $clubId ? (string) $clubId : '';
+            $this->view('usuarios/create', [
+                'data' => array_merge($this->defaultData(), $input),
+                'errors' => $errors,
+                'roles' => $roles,
+                'clubs' => Club::options(),
+            ]);
+            return;
+        }
+
+        $payload = [
+            'id_club' => $clubId,
+            'nombres' => $input['nombres'],
+            'apellidos' => $input['apellidos'],
+            'tipo_documento' => $input['tipo_documento'] ?: null,
+            'documento' => $input['documento'],
+            'correo' => $input['correo'],
+            'clave' => password_hash($input['clave'], PASSWORD_BCRYPT),
+            'rol' => $input['rol'],
+            'fecha_nacimiento' => $input['fecha_nacimiento'] ?: null,
+            'tipo_sangre' => $input['tipo_sangre'] ?: null,
+            'celular' => $input['celular'] ?: null,
+            'estado' => $input['estado'],
+            'documento_operador' => $input['documento_operador'] ?: null,
+        ];
+
+        try {
+            Usuario::create($payload);
+        } catch (PDOException $e) {
+            $this->view('usuarios/create', [
+                'data' => array_merge($this->defaultData(), $input, ['id_club' => $clubId ? (string) $clubId : '']),
+                'errors' => ['general' => 'No fue posible registrar el usuario. Verifica la información e intenta nuevamente.'],
+                'roles' => $roles,
+                'clubs' => Club::options(),
+            ]);
+            return;
+        }
+
+        $this->redirect('/usuarios', ['status' => 'created']);
+    }
+
+    private function defaultData(): array
+    {
+        return [
+            'id_club' => '',
+            'nombres' => '',
+            'apellidos' => '',
+            'tipo_documento' => '',
+            'documento' => '',
+            'correo' => '',
+            'clave' => '',
+            'rol' => 'deportista',
+            'fecha_nacimiento' => '',
+            'tipo_sangre' => '',
+            'celular' => '',
+            'estado' => 'activo',
+            'documento_operador' => '',
+        ];
+    }
+}

--- a/cronoportes/app/models/Club.php
+++ b/cronoportes/app/models/Club.php
@@ -1,0 +1,38 @@
+<?php
+namespace App\Models;
+
+class Club extends Model
+{
+    protected static string $table = 'clubs';
+
+    public static function all(): array
+    {
+        $stmt = self::db()->query('SELECT * FROM ' . self::$table . ' ORDER BY nombre_club');
+        return $stmt->fetchAll();
+    }
+
+    public static function options(): array
+    {
+        $stmt = self::db()->query('SELECT id_club, nombre_club FROM ' . self::$table . ' WHERE estado = "activo" ORDER BY nombre_club');
+        return $stmt->fetchAll();
+    }
+
+    public static function create(array $data): int
+    {
+        $sql = 'INSERT INTO ' . self::$table . ' (nombre_club, correo_contacto, telefono_contacto, direccion, estado, documento_operador)'
+            . ' VALUES (:nombre_club, :correo_contacto, :telefono_contacto, :direccion, :estado, :documento_operador)';
+
+        $stmt = self::db()->prepare($sql);
+
+        $stmt->execute([
+            'nombre_club' => $data['nombre_club'],
+            'correo_contacto' => $data['correo_contacto'],
+            'telefono_contacto' => $data['telefono_contacto'],
+            'direccion' => $data['direccion'],
+            'estado' => $data['estado'],
+            'documento_operador' => $data['documento_operador'],
+        ]);
+
+        return (int) self::db()->lastInsertId();
+    }
+}

--- a/cronoportes/app/models/Club.php
+++ b/cronoportes/app/models/Club.php
@@ -35,4 +35,18 @@ class Club extends Model
 
         return (int) self::db()->lastInsertId();
     }
+
+    public static function countAll(): int
+    {
+        $stmt = self::db()->query('SELECT COUNT(*) AS total FROM ' . self::$table);
+        $row = $stmt->fetch();
+
+        return (int) ($row['total'] ?? 0);
+    }
+
+    public static function deleteById(int $id): void
+    {
+        $stmt = self::db()->prepare('DELETE FROM ' . self::$table . ' WHERE id_club = :id LIMIT 1');
+        $stmt->execute(['id' => $id]);
+    }
 }

--- a/cronoportes/app/models/Model.php
+++ b/cronoportes/app/models/Model.php
@@ -1,0 +1,43 @@
+<?php
+namespace App\Models;
+
+use PDO;
+use PDOException;
+
+class Model
+{
+    protected static PDO $connection;
+
+    public static function init(array $config): void
+    {
+        if (isset(self::$connection)) {
+            return;
+        }
+
+        $dsn = sprintf(
+            'mysql:host=%s;port=%s;dbname=%s;charset=%s',
+            $config['host'],
+            $config['port'],
+            $config['database'],
+            $config['charset']
+        );
+
+        try {
+            self::$connection = new PDO($dsn, $config['username'], $config['password'], [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            ]);
+        } catch (PDOException $e) {
+            throw new PDOException('Error al conectar con la base de datos: ' . $e->getMessage());
+        }
+    }
+
+    protected static function db(): PDO
+    {
+        if (!isset(self::$connection)) {
+            throw new PDOException('La conexión a la base de datos no se ha inicializado.');
+        }
+
+        return self::$connection;
+    }
+}

--- a/cronoportes/app/models/Usuario.php
+++ b/cronoportes/app/models/Usuario.php
@@ -31,6 +31,16 @@ class Usuario extends Model
         return ['superadmin', 'admin', 'instructor', 'deportista', 'acudiente', 'tesorero'];
     }
 
+    public static function findByCorreo(string $correo): ?array
+    {
+        $sql = 'SELECT * FROM ' . self::$table . ' WHERE correo = :correo LIMIT 1';
+        $stmt = self::db()->prepare($sql);
+        $stmt->execute(['correo' => $correo]);
+        $result = $stmt->fetch();
+
+        return $result ?: null;
+    }
+
     public static function create(array $data): int
     {
         $sql = 'INSERT INTO ' . self::$table

--- a/cronoportes/app/models/Usuario.php
+++ b/cronoportes/app/models/Usuario.php
@@ -1,0 +1,60 @@
+<?php
+namespace App\Models;
+
+class Usuario extends Model
+{
+    protected static string $table = 'usuarios';
+
+    public static function all(): array
+    {
+        $sql = 'SELECT u.*, c.nombre_club FROM ' . self::$table . ' u'
+            . ' LEFT JOIN clubs c ON u.id_club = c.id_club'
+            . ' ORDER BY u.nombres, u.apellidos';
+        $stmt = self::db()->query($sql);
+        return $stmt->fetchAll();
+    }
+
+    public static function find(int $id): ?array
+    {
+        $sql = 'SELECT u.*, c.nombre_club FROM ' . self::$table . ' u'
+            . ' LEFT JOIN clubs c ON u.id_club = c.id_club'
+            . ' WHERE u.id_usuario = :id LIMIT 1';
+        $stmt = self::db()->prepare($sql);
+        $stmt->execute(['id' => $id]);
+        $result = $stmt->fetch();
+
+        return $result ?: null;
+    }
+
+    public static function roles(): array
+    {
+        return ['superadmin', 'admin', 'instructor', 'deportista', 'acudiente', 'tesorero'];
+    }
+
+    public static function create(array $data): int
+    {
+        $sql = 'INSERT INTO ' . self::$table
+            . ' (id_club, nombres, apellidos, tipo_documento, documento, correo, clave, rol, fecha_nacimiento, tipo_sangre, celular, estado, documento_operador)'
+            . ' VALUES (:id_club, :nombres, :apellidos, :tipo_documento, :documento, :correo, :clave, :rol, :fecha_nacimiento, :tipo_sangre, :celular, :estado, :documento_operador)';
+
+        $stmt = self::db()->prepare($sql);
+
+        $stmt->execute([
+            'id_club' => $data['id_club'],
+            'nombres' => $data['nombres'],
+            'apellidos' => $data['apellidos'],
+            'tipo_documento' => $data['tipo_documento'],
+            'documento' => $data['documento'],
+            'correo' => $data['correo'],
+            'clave' => $data['clave'],
+            'rol' => $data['rol'],
+            'fecha_nacimiento' => $data['fecha_nacimiento'],
+            'tipo_sangre' => $data['tipo_sangre'],
+            'celular' => $data['celular'],
+            'estado' => $data['estado'],
+            'documento_operador' => $data['documento_operador'],
+        ]);
+
+        return (int) self::db()->lastInsertId();
+    }
+}

--- a/cronoportes/app/views/auth/login.php
+++ b/cronoportes/app/views/auth/login.php
@@ -1,0 +1,33 @@
+<?php
+$title = 'Ingresar a CronoDep';
+$data = $data ?? ['correo' => ''];
+$errors = $errors ?? [];
+?>
+<section class="auth-card">
+    <h2>Iniciar sesión</h2>
+    <?php if (!empty($errors['general'])): ?>
+        <p class="alert alert-error"><?= htmlspecialchars($errors['general']) ?></p>
+    <?php endif; ?>
+    <form method="post" action="<?= htmlspecialchars(route('/login')) ?>" class="form-grid">
+        <div class="form-control">
+            <label for="correo">Correo electrónico</label>
+            <input type="email" name="correo" id="correo" value="<?= htmlspecialchars($data['correo'] ?? '') ?>" required>
+            <?php if (!empty($errors['correo'])): ?>
+                <small class="error"><?= htmlspecialchars($errors['correo']) ?></small>
+            <?php endif; ?>
+        </div>
+        <div class="form-control">
+            <label for="clave">Contraseña</label>
+            <input type="password" name="clave" id="clave" required>
+            <?php if (!empty($errors['clave'])): ?>
+                <small class="error"><?= htmlspecialchars($errors['clave']) ?></small>
+            <?php endif; ?>
+        </div>
+        <button type="submit" class="btn-primary">Ingresar</button>
+    </form>
+    <?php if ((int) ($data['clubs_registrados'] ?? 1) === 0): ?>
+        <p class="help-text">
+            ¿Aún no tienes tu club? <a href="<?= htmlspecialchars(route('/register-club')) ?>">Registra el primero aquí</a>.
+        </p>
+    <?php endif; ?>
+</section>

--- a/cronoportes/app/views/auth/register_club.php
+++ b/cronoportes/app/views/auth/register_club.php
@@ -1,0 +1,89 @@
+<?php
+$title = 'Registrar primer club';
+$data = $data ?? [];
+$errors = $errors ?? [];
+?>
+<section class="auth-card">
+    <h2>Registrar primer club</h2>
+    <p class="help-text">Este formulario creará el primer club y un usuario con rol Superadmin.</p>
+    <?php if (!empty($errors['general'])): ?>
+        <p class="alert alert-error"><?= htmlspecialchars($errors['general']) ?></p>
+    <?php endif; ?>
+    <form method="post" action="<?= htmlspecialchars(route('/register-club')) ?>" class="form-grid">
+        <fieldset>
+            <legend>Datos del club</legend>
+            <div class="form-control">
+                <label for="nombre_club">Nombre del club</label>
+                <input type="text" name="nombre_club" id="nombre_club" value="<?= htmlspecialchars($data['nombre_club'] ?? '') ?>" required>
+                <?php if (!empty($errors['nombre_club'])): ?>
+                    <small class="error"><?= htmlspecialchars($errors['nombre_club']) ?></small>
+                <?php endif; ?>
+            </div>
+            <div class="form-control">
+                <label for="correo_contacto">Correo de contacto</label>
+                <input type="email" name="correo_contacto" id="correo_contacto" value="<?= htmlspecialchars($data['correo_contacto'] ?? '') ?>">
+                <?php if (!empty($errors['correo_contacto'])): ?>
+                    <small class="error"><?= htmlspecialchars($errors['correo_contacto']) ?></small>
+                <?php endif; ?>
+            </div>
+            <div class="form-control">
+                <label for="telefono_contacto">Teléfono de contacto</label>
+                <input type="text" name="telefono_contacto" id="telefono_contacto" value="<?= htmlspecialchars($data['telefono_contacto'] ?? '') ?>">
+            </div>
+            <div class="form-control">
+                <label for="direccion">Dirección</label>
+                <input type="text" name="direccion" id="direccion" value="<?= htmlspecialchars($data['direccion'] ?? '') ?>">
+            </div>
+            <div class="form-control">
+                <label for="documento_operador">Documento del operador</label>
+                <input type="text" name="documento_operador" id="documento_operador" value="<?= htmlspecialchars($data['documento_operador'] ?? '') ?>">
+            </div>
+        </fieldset>
+        <fieldset>
+            <legend>Usuario superadministrador</legend>
+            <div class="form-control">
+                <label for="nombres">Nombres</label>
+                <input type="text" name="nombres" id="nombres" value="<?= htmlspecialchars($data['nombres'] ?? '') ?>" required>
+                <?php if (!empty($errors['nombres'])): ?>
+                    <small class="error"><?= htmlspecialchars($errors['nombres']) ?></small>
+                <?php endif; ?>
+            </div>
+            <div class="form-control">
+                <label for="apellidos">Apellidos</label>
+                <input type="text" name="apellidos" id="apellidos" value="<?= htmlspecialchars($data['apellidos'] ?? '') ?>" required>
+                <?php if (!empty($errors['apellidos'])): ?>
+                    <small class="error"><?= htmlspecialchars($errors['apellidos']) ?></small>
+                <?php endif; ?>
+            </div>
+            <div class="form-control">
+                <label for="documento">Documento</label>
+                <input type="text" name="documento" id="documento" value="<?= htmlspecialchars($data['documento'] ?? '') ?>" required>
+                <?php if (!empty($errors['documento'])): ?>
+                    <small class="error"><?= htmlspecialchars($errors['documento']) ?></small>
+                <?php endif; ?>
+            </div>
+            <div class="form-control">
+                <label for="correo">Correo de acceso</label>
+                <input type="email" name="correo" id="correo" value="<?= htmlspecialchars($data['correo'] ?? '') ?>" required>
+                <?php if (!empty($errors['correo'])): ?>
+                    <small class="error"><?= htmlspecialchars($errors['correo']) ?></small>
+                <?php endif; ?>
+            </div>
+            <div class="form-control">
+                <label for="clave">Contraseña</label>
+                <input type="password" name="clave" id="clave" required>
+                <?php if (!empty($errors['clave'])): ?>
+                    <small class="error"><?= htmlspecialchars($errors['clave']) ?></small>
+                <?php endif; ?>
+            </div>
+            <div class="form-control">
+                <label for="confirmacion">Confirmar contraseña</label>
+                <input type="password" name="confirmacion" id="confirmacion" required>
+                <?php if (!empty($errors['confirmacion'])): ?>
+                    <small class="error"><?= htmlspecialchars($errors['confirmacion']) ?></small>
+                <?php endif; ?>
+            </div>
+        </fieldset>
+        <button type="submit" class="btn-primary">Crear club y acceder</button>
+    </form>
+</section>

--- a/cronoportes/app/views/clubs/create.php
+++ b/cronoportes/app/views/clubs/create.php
@@ -1,0 +1,56 @@
+<?php
+$titulo = 'Registrar club';
+?>
+<section class="form-card">
+    <h2>Nuevo club</h2>
+
+    <?php if (!empty($errors['general'])): ?>
+        <div class="alert alert-error"><?= htmlspecialchars($errors['general']) ?></div>
+    <?php endif; ?>
+
+    <form method="post" action="<?= htmlspecialchars(route('clubs')) ?>" class="form-grid">
+        <div class="form-group">
+            <label for="nombre_club">Nombre *</label>
+            <input type="text" id="nombre_club" name="nombre_club" value="<?= htmlspecialchars($data['nombre_club']) ?>" required>
+            <?php if (!empty($errors['nombre_club'])): ?>
+                <small class="form-error"><?= htmlspecialchars($errors['nombre_club']) ?></small>
+            <?php endif; ?>
+        </div>
+
+        <div class="form-group">
+            <label for="correo_contacto">Correo de contacto</label>
+            <input type="email" id="correo_contacto" name="correo_contacto" value="<?= htmlspecialchars($data['correo_contacto']) ?>">
+            <?php if (!empty($errors['correo_contacto'])): ?>
+                <small class="form-error"><?= htmlspecialchars($errors['correo_contacto']) ?></small>
+            <?php endif; ?>
+        </div>
+
+        <div class="form-group">
+            <label for="telefono_contacto">Teléfono</label>
+            <input type="text" id="telefono_contacto" name="telefono_contacto" value="<?= htmlspecialchars($data['telefono_contacto']) ?>">
+        </div>
+
+        <div class="form-group">
+            <label for="direccion">Dirección</label>
+            <input type="text" id="direccion" name="direccion" value="<?= htmlspecialchars($data['direccion']) ?>">
+        </div>
+
+        <div class="form-group">
+            <label for="estado">Estado *</label>
+            <select id="estado" name="estado">
+                <option value="activo" <?= $data['estado'] === 'activo' ? 'selected' : '' ?>>Activo</option>
+                <option value="inactivo" <?= $data['estado'] === 'inactivo' ? 'selected' : '' ?>>Inactivo</option>
+            </select>
+        </div>
+
+        <div class="form-group">
+            <label for="documento_operador">Documento del operador</label>
+            <input type="text" id="documento_operador" name="documento_operador" value="<?= htmlspecialchars($data['documento_operador']) ?>">
+        </div>
+
+        <div class="form-actions">
+            <button type="submit" class="btn">Guardar</button>
+            <a class="btn btn-secondary" href="<?= htmlspecialchars(route('clubs')) ?>">Cancelar</a>
+        </div>
+    </form>
+</section>

--- a/cronoportes/app/views/clubs/index.php
+++ b/cronoportes/app/views/clubs/index.php
@@ -1,0 +1,38 @@
+<?php
+$titulo = 'Listado de clubs';
+?>
+<section>
+    <div class="section-header">
+        <h2>Clubs</h2>
+        <a class="btn" href="<?= htmlspecialchars(route('clubs/crear')) ?>">Registrar club</a>
+    </div>
+
+    <?php if (!empty($message)): ?>
+        <div class="alert alert-success"><?= htmlspecialchars($message) ?></div>
+    <?php endif; ?>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Nombre</th>
+                <th>Correo</th>
+                <th>Teléfono</th>
+                <th>Estado</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (empty($clubs)): ?>
+            <tr><td colspan="4">No hay clubs registrados.</td></tr>
+        <?php else: ?>
+            <?php foreach ($clubs as $club): ?>
+                <tr>
+                    <td><?= htmlspecialchars($club['nombre_club']) ?></td>
+                    <td><?= htmlspecialchars($club['correo_contacto']) ?></td>
+                    <td><?= htmlspecialchars($club['telefono_contacto']) ?></td>
+                    <td><?= htmlspecialchars($club['estado']) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</section>

--- a/cronoportes/app/views/dashboard/admin.php
+++ b/cronoportes/app/views/dashboard/admin.php
@@ -1,0 +1,61 @@
+<?php
+$title = 'Panel Administrador';
+$usuario = $usuario ?? [];
+$usuarios = $usuarios ?? [];
+$clubs = $clubs ?? [];
+$clubActual = null;
+$clubId = $usuario['id_club'] ?? null;
+if ($clubId) {
+    foreach ($clubs as $club) {
+        if ((int) $club['id_club'] === (int) $clubId) {
+            $clubActual = $club;
+            break;
+        }
+    }
+}
+$usuariosClub = array_filter($usuarios, static function ($item) use ($clubId) {
+    return (int) ($item['id_club'] ?? 0) === (int) $clubId;
+});
+?>
+<section class="dashboard">
+    <h2>Hola, <?= htmlspecialchars($usuario['nombre'] ?? 'Administrador') ?></h2>
+    <p class="help-text">Desde aquí puedes gestionar a tu equipo y mantener actualizado tu club.</p>
+    <div class="dashboard-grid">
+        <article class="card">
+            <h3>Mi club</h3>
+            <p><?= htmlspecialchars($clubActual['nombre_club'] ?? 'Sin club asignado') ?></p>
+        </article>
+        <article class="card">
+            <h3>Usuarios del club</h3>
+            <p><?= count($usuariosClub) ?></p>
+        </article>
+    </div>
+</section>
+<section>
+    <div class="section-header">
+        <h2>Equipo activo</h2>
+        <a class="btn" href="<?= htmlspecialchars(route('/usuarios')) ?>">Gestionar usuarios</a>
+    </div>
+    <table>
+        <thead>
+            <tr>
+                <th>Nombre</th>
+                <th>Rol</th>
+                <th>Correo</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (empty($usuariosClub)): ?>
+            <tr><td colspan="3">No hay usuarios asignados a tu club.</td></tr>
+        <?php else: ?>
+            <?php foreach ($usuariosClub as $item): ?>
+                <tr>
+                    <td><?= htmlspecialchars($item['nombres'] . ' ' . $item['apellidos']) ?></td>
+                    <td><?= htmlspecialchars($item['rol']) ?></td>
+                    <td><?= htmlspecialchars($item['correo']) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</section>

--- a/cronoportes/app/views/dashboard/deportista.php
+++ b/cronoportes/app/views/dashboard/deportista.php
@@ -1,0 +1,27 @@
+<?php
+$title = 'Mi espacio deportivo';
+$usuario = $usuario ?? [];
+?>
+<section class="dashboard">
+    <h2>Hola, <?= htmlspecialchars($usuario['nombre'] ?? 'Deportista') ?></h2>
+    <p class="help-text">
+        Aquí podrás consultar tus entrenamientos, pagos y notificaciones una vez estén disponibles.
+    </p>
+    <div class="dashboard-grid">
+        <article class="card">
+            <h3>Próximamente</h3>
+            <p>Resúmenes de tus sesiones de entrenamiento y métricas personales.</p>
+        </article>
+        <article class="card">
+            <h3>Pagos y estado</h3>
+            <p>Seguimiento a tus mensualidades y matrículas.</p>
+        </article>
+    </div>
+</section>
+<section>
+    <h2>¿Necesitas ayuda?</h2>
+    <p>
+        Comunícate con el administrador de tu club para actualizar tus datos o resolver inquietudes.
+        Pronto habilitaremos un buzón de soporte para reportar novedades.
+    </p>
+</section>

--- a/cronoportes/app/views/dashboard/superadmin.php
+++ b/cronoportes/app/views/dashboard/superadmin.php
@@ -1,0 +1,76 @@
+<?php
+$title = 'Panel Superadmin';
+$usuario = $usuario ?? [];
+$usuarios = $usuarios ?? [];
+$clubs = $clubs ?? [];
+?>
+<section class="dashboard">
+    <h2>Hola, <?= htmlspecialchars($usuario['nombre'] ?? 'Superadmin') ?></h2>
+    <p class="help-text">Gestiona la plataforma y supervisa la operación de todos los clubes.</p>
+    <div class="dashboard-grid">
+        <article class="card">
+            <h3>Clubs activos</h3>
+            <p><?= count($clubs) ?></p>
+        </article>
+        <article class="card">
+            <h3>Usuarios registrados</h3>
+            <p><?= count($usuarios) ?></p>
+        </article>
+    </div>
+</section>
+<section>
+    <div class="section-header">
+        <h2>Usuarios recientes</h2>
+        <a class="btn" href="<?= htmlspecialchars(route('/usuarios')) ?>">Gestionar usuarios</a>
+    </div>
+    <table>
+        <thead>
+            <tr>
+                <th>Nombre</th>
+                <th>Rol</th>
+                <th>Correo</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (empty($usuarios)): ?>
+            <tr><td colspan="3">No hay usuarios registrados.</td></tr>
+        <?php else: ?>
+            <?php foreach (array_slice($usuarios, 0, 5) as $item): ?>
+                <tr>
+                    <td><?= htmlspecialchars($item['nombres'] . ' ' . $item['apellidos']) ?></td>
+                    <td><?= htmlspecialchars($item['rol']) ?></td>
+                    <td><?= htmlspecialchars($item['correo']) ?></td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</section>
+<section>
+    <div class="section-header">
+        <h2>Clubs registrados</h2>
+        <a class="btn" href="<?= htmlspecialchars(route('/clubs')) ?>">Ver listado completo</a>
+    </div>
+    <table>
+        <thead>
+            <tr>
+                <th>Nombre</th>
+                <th>Correo</th>
+                <th>Teléfono</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (empty($clubs)): ?>
+            <tr><td colspan="3">No hay clubs registrados.</td></tr>
+        <?php else: ?>
+            <?php foreach ($clubs as $club): ?>
+                <tr>
+                    <td><?= htmlspecialchars($club['nombre_club']) ?></td>
+                    <td><?= htmlspecialchars($club['correo_contacto'] ?? 'N/D') ?></td>
+                    <td><?= htmlspecialchars($club['telefono_contacto'] ?? 'N/D') ?></td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</section>

--- a/cronoportes/app/views/home/index.php
+++ b/cronoportes/app/views/home/index.php
@@ -1,43 +1,34 @@
 <?php
-$titulo = 'Panel principal';
+$title = 'Bienvenido a CronoDep';
+$clubsRegistrados = $clubsRegistrados ?? 0;
 ?>
-<section class="dashboard">
-    <h2>Resumen general</h2>
-    <div class="dashboard-grid">
+<section class="landing">
+    <div class="landing-hero">
+        <h2>Gestión integral de entrenamientos y clubes deportivos</h2>
+        <p>
+            CronoDep centraliza el control de deportistas, entrenadores y pagos en una única plataforma.
+            Administra tus sesiones, registra la asistencia y genera reportes en segundos.
+        </p>
+        <div class="landing-actions">
+            <?php if ($clubsRegistrados === 0): ?>
+                <a class="btn" href="<?= htmlspecialchars(route('/register-club')) ?>">Crear mi primer club</a>
+            <?php else: ?>
+                <a class="btn" href="<?= htmlspecialchars(route('/login')) ?>">Iniciar sesión</a>
+            <?php endif; ?>
+        </div>
+    </div>
+    <div class="landing-summary">
         <article class="card">
-            <h3>Total de usuarios</h3>
-            <p><?= count($usuarios) ?></p>
+            <h3>Roles soportados</h3>
+            <p>Superadmins, administradores, instructores, deportistas, acudientes y tesoreros.</p>
         </article>
         <article class="card">
-            <h3>Total de clubs</h3>
-            <p><?= count($clubs) ?></p>
+            <h3>Base de datos lista</h3>
+            <p>Compatibilidad con MariaDB y la estructura definida para clubes, usuarios y entrenamientos.</p>
+        </article>
+        <article class="card">
+            <h3>Seguridad integrada</h3>
+            <p>Inicio de sesión con contraseñas cifradas y control de acceso por roles.</p>
         </article>
     </div>
-</section>
-<section>
-    <h2>Usuarios recientes</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Nombre</th>
-                <th>Documento</th>
-                <th>Rol</th>
-                <th>Club</th>
-            </tr>
-        </thead>
-        <tbody>
-        <?php if (empty($usuarios)): ?>
-            <tr><td colspan="4">No hay usuarios registrados.</td></tr>
-        <?php else: ?>
-            <?php foreach (array_slice($usuarios, 0, 5) as $usuario): ?>
-                <tr>
-                    <td><?= htmlspecialchars($usuario['nombres'] . ' ' . $usuario['apellidos']) ?></td>
-                    <td><?= htmlspecialchars($usuario['documento']) ?></td>
-                    <td><?= htmlspecialchars($usuario['rol']) ?></td>
-                    <td><?= htmlspecialchars($usuario['nombre_club'] ?? 'Sin club') ?></td>
-                </tr>
-            <?php endforeach; ?>
-        <?php endif; ?>
-        </tbody>
-    </table>
 </section>

--- a/cronoportes/app/views/home/index.php
+++ b/cronoportes/app/views/home/index.php
@@ -1,0 +1,43 @@
+<?php
+$titulo = 'Panel principal';
+?>
+<section class="dashboard">
+    <h2>Resumen general</h2>
+    <div class="dashboard-grid">
+        <article class="card">
+            <h3>Total de usuarios</h3>
+            <p><?= count($usuarios) ?></p>
+        </article>
+        <article class="card">
+            <h3>Total de clubs</h3>
+            <p><?= count($clubs) ?></p>
+        </article>
+    </div>
+</section>
+<section>
+    <h2>Usuarios recientes</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Nombre</th>
+                <th>Documento</th>
+                <th>Rol</th>
+                <th>Club</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (empty($usuarios)): ?>
+            <tr><td colspan="4">No hay usuarios registrados.</td></tr>
+        <?php else: ?>
+            <?php foreach (array_slice($usuarios, 0, 5) as $usuario): ?>
+                <tr>
+                    <td><?= htmlspecialchars($usuario['nombres'] . ' ' . $usuario['apellidos']) ?></td>
+                    <td><?= htmlspecialchars($usuario['documento']) ?></td>
+                    <td><?= htmlspecialchars($usuario['rol']) ?></td>
+                    <td><?= htmlspecialchars($usuario['nombre_club'] ?? 'Sin club') ?></td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</section>

--- a/cronoportes/app/views/layouts/main.php
+++ b/cronoportes/app/views/layouts/main.php
@@ -1,13 +1,15 @@
 <?php
 $baseUrl = $GLOBALS['baseUrl'] ?? '';
 $assetBase = $baseUrl === '/' ? '' : rtrim($baseUrl, '/');
+$usuarioSesion = $_SESSION['usuario'] ?? null;
+$rolSesion = $_SESSION['rol'] ?? null;
 ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><?= htmlspecialchars($titulo ?? ($GLOBALS['appName'] ?? 'CronoDep')) ?></title>
+    <title><?= htmlspecialchars($title ?? 'Control Entrenamientos Deportivos') ?></title>
     <link rel="stylesheet" href="<?= htmlspecialchars($assetBase . '/public/css/styles.css') ?>">
 </head>
 <body>
@@ -15,12 +17,22 @@ $assetBase = $baseUrl === '/' ? '' : rtrim($baseUrl, '/');
     <h1><?= htmlspecialchars($GLOBALS['appName'] ?? 'CronoDep') ?></h1>
     <nav>
         <a href="<?= htmlspecialchars(route('/')) ?>">Inicio</a>
-        <a href="<?= htmlspecialchars(route('usuarios')) ?>">Usuarios</a>
-        <a href="<?= htmlspecialchars(route('clubs')) ?>">Clubs</a>
+        <?php if ($usuarioSesion): ?>
+            <a href="<?= htmlspecialchars(route('/dashboard')) ?>">Panel</a>
+            <?php if (in_array($rolSesion, ['superadmin', 'admin'], true)): ?>
+                <a href="<?= htmlspecialchars(route('/usuarios')) ?>">Usuarios</a>
+                <a href="<?= htmlspecialchars(route('/clubs')) ?>">Clubs</a>
+            <?php endif; ?>
+            <form action="<?= htmlspecialchars(route('/logout')) ?>" method="post" class="logout-form">
+                <button type="submit">Cerrar sesión</button>
+            </form>
+        <?php else: ?>
+            <a href="<?= htmlspecialchars(route('/login')) ?>">Ingresar</a>
+        <?php endif; ?>
     </nav>
 </header>
 <main class="app-content">
-    <?php if (isset($contentFile)) { include $contentFile; } ?>
+    <?= $content ?? '' ?>
 </main>
 <script src="<?= htmlspecialchars($assetBase . '/public/js/app.js') ?>"></script>
 </body>

--- a/cronoportes/app/views/layouts/main.php
+++ b/cronoportes/app/views/layouts/main.php
@@ -1,0 +1,27 @@
+<?php
+$baseUrl = $GLOBALS['baseUrl'] ?? '';
+$assetBase = $baseUrl === '/' ? '' : rtrim($baseUrl, '/');
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($titulo ?? ($GLOBALS['appName'] ?? 'CronoDep')) ?></title>
+    <link rel="stylesheet" href="<?= htmlspecialchars($assetBase . '/public/css/styles.css') ?>">
+</head>
+<body>
+<header class="app-header">
+    <h1><?= htmlspecialchars($GLOBALS['appName'] ?? 'CronoDep') ?></h1>
+    <nav>
+        <a href="<?= htmlspecialchars(route('/')) ?>">Inicio</a>
+        <a href="<?= htmlspecialchars(route('usuarios')) ?>">Usuarios</a>
+        <a href="<?= htmlspecialchars(route('clubs')) ?>">Clubs</a>
+    </nav>
+</header>
+<main class="app-content">
+    <?php if (isset($contentFile)) { include $contentFile; } ?>
+</main>
+<script src="<?= htmlspecialchars($assetBase . '/public/js/app.js') ?>"></script>
+</body>
+</html>

--- a/cronoportes/app/views/usuarios/create.php
+++ b/cronoportes/app/views/usuarios/create.php
@@ -1,0 +1,118 @@
+<?php
+$titulo = 'Registrar usuario';
+?>
+<section class="form-card">
+    <h2>Nuevo usuario</h2>
+
+    <?php if (!empty($errors['general'])): ?>
+        <div class="alert alert-error"><?= htmlspecialchars($errors['general']) ?></div>
+    <?php endif; ?>
+
+    <form method="post" action="<?= htmlspecialchars(route('usuarios')) ?>" class="form-grid">
+        <div class="form-group">
+            <label for="nombres">Nombres *</label>
+            <input type="text" id="nombres" name="nombres" value="<?= htmlspecialchars($data['nombres']) ?>" required>
+            <?php if (!empty($errors['nombres'])): ?>
+                <small class="form-error"><?= htmlspecialchars($errors['nombres']) ?></small>
+            <?php endif; ?>
+        </div>
+
+        <div class="form-group">
+            <label for="apellidos">Apellidos *</label>
+            <input type="text" id="apellidos" name="apellidos" value="<?= htmlspecialchars($data['apellidos']) ?>" required>
+            <?php if (!empty($errors['apellidos'])): ?>
+                <small class="form-error"><?= htmlspecialchars($errors['apellidos']) ?></small>
+            <?php endif; ?>
+        </div>
+
+        <div class="form-group">
+            <label for="tipo_documento">Tipo de documento</label>
+            <input type="text" id="tipo_documento" name="tipo_documento" value="<?= htmlspecialchars($data['tipo_documento']) ?>">
+        </div>
+
+        <div class="form-group">
+            <label for="documento">Documento *</label>
+            <input type="text" id="documento" name="documento" value="<?= htmlspecialchars($data['documento']) ?>" required>
+            <?php if (!empty($errors['documento'])): ?>
+                <small class="form-error"><?= htmlspecialchars($errors['documento']) ?></small>
+            <?php endif; ?>
+        </div>
+
+        <div class="form-group">
+            <label for="correo">Correo electrónico *</label>
+            <input type="email" id="correo" name="correo" value="<?= htmlspecialchars($data['correo']) ?>" required>
+            <?php if (!empty($errors['correo'])): ?>
+                <small class="form-error"><?= htmlspecialchars($errors['correo']) ?></small>
+            <?php endif; ?>
+        </div>
+
+        <div class="form-group">
+            <label for="clave">Clave *</label>
+            <input type="password" id="clave" name="clave" required>
+            <?php if (!empty($errors['clave'])): ?>
+                <small class="form-error"><?= htmlspecialchars($errors['clave']) ?></small>
+            <?php endif; ?>
+        </div>
+
+        <div class="form-group">
+            <label for="rol">Rol *</label>
+            <select id="rol" name="rol" required>
+                <option value="">Selecciona un rol</option>
+                <?php foreach ($roles as $rol): ?>
+                    <option value="<?= htmlspecialchars($rol) ?>" <?= $data['rol'] === $rol ? 'selected' : '' ?>><?= ucfirst($rol) ?></option>
+                <?php endforeach; ?>
+            </select>
+            <?php if (!empty($errors['rol'])): ?>
+                <small class="form-error"><?= htmlspecialchars($errors['rol']) ?></small>
+            <?php endif; ?>
+        </div>
+
+        <div class="form-group">
+            <label for="id_club">Club</label>
+            <select id="id_club" name="id_club">
+                <option value="">Sin asignar</option>
+                <?php foreach ($clubs as $club): ?>
+                    <option value="<?= (int) $club['id_club'] ?>" <?= (string) $club['id_club'] === (string) $data['id_club'] ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($club['nombre_club']) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+
+        <div class="form-group">
+            <label for="fecha_nacimiento">Fecha de nacimiento</label>
+            <input type="date" id="fecha_nacimiento" name="fecha_nacimiento" value="<?= htmlspecialchars($data['fecha_nacimiento']) ?>">
+            <?php if (!empty($errors['fecha_nacimiento'])): ?>
+                <small class="form-error"><?= htmlspecialchars($errors['fecha_nacimiento']) ?></small>
+            <?php endif; ?>
+        </div>
+
+        <div class="form-group">
+            <label for="tipo_sangre">Tipo de sangre</label>
+            <input type="text" id="tipo_sangre" name="tipo_sangre" value="<?= htmlspecialchars($data['tipo_sangre']) ?>">
+        </div>
+
+        <div class="form-group">
+            <label for="celular">Celular</label>
+            <input type="text" id="celular" name="celular" value="<?= htmlspecialchars($data['celular']) ?>">
+        </div>
+
+        <div class="form-group">
+            <label for="estado">Estado *</label>
+            <select id="estado" name="estado">
+                <option value="activo" <?= $data['estado'] === 'activo' ? 'selected' : '' ?>>Activo</option>
+                <option value="inactivo" <?= $data['estado'] === 'inactivo' ? 'selected' : '' ?>>Inactivo</option>
+            </select>
+        </div>
+
+        <div class="form-group">
+            <label for="documento_operador">Documento del operador</label>
+            <input type="text" id="documento_operador" name="documento_operador" value="<?= htmlspecialchars($data['documento_operador']) ?>">
+        </div>
+
+        <div class="form-actions">
+            <button type="submit" class="btn">Guardar</button>
+            <a class="btn btn-secondary" href="<?= htmlspecialchars(route('usuarios')) ?>">Cancelar</a>
+        </div>
+    </form>
+</section>

--- a/cronoportes/app/views/usuarios/index.php
+++ b/cronoportes/app/views/usuarios/index.php
@@ -1,0 +1,42 @@
+<?php
+$titulo = 'Listado de usuarios';
+?>
+<section>
+    <div class="section-header">
+        <h2>Usuarios</h2>
+        <a class="btn" href="<?= htmlspecialchars(route('usuarios/crear')) ?>">Registrar usuario</a>
+    </div>
+
+    <?php if (!empty($message)): ?>
+        <div class="alert alert-success"><?= htmlspecialchars($message) ?></div>
+    <?php endif; ?>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Nombre</th>
+                <th>Documento</th>
+                <th>Correo</th>
+                <th>Rol</th>
+                <th>Club</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (empty($usuarios)): ?>
+            <tr><td colspan="6">No hay usuarios registrados.</td></tr>
+        <?php else: ?>
+            <?php foreach ($usuarios as $usuario): ?>
+                <tr>
+                    <td><?= htmlspecialchars($usuario['nombres'] . ' ' . $usuario['apellidos']) ?></td>
+                    <td><?= htmlspecialchars($usuario['documento']) ?></td>
+                    <td><?= htmlspecialchars($usuario['correo']) ?></td>
+                    <td><?= htmlspecialchars($usuario['rol']) ?></td>
+                    <td><?= htmlspecialchars($usuario['nombre_club'] ?? 'Sin club') ?></td>
+                    <td><a class="btn btn-small" href="<?= htmlspecialchars(route('usuarios/' . $usuario['id_usuario'])) ?>">Ver</a></td>
+                </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</section>

--- a/cronoportes/app/views/usuarios/show.php
+++ b/cronoportes/app/views/usuarios/show.php
@@ -1,0 +1,21 @@
+<?php
+$titulo = 'Detalle de usuario';
+?>
+<section>
+    <h2><?= htmlspecialchars($usuario['nombres'] . ' ' . $usuario['apellidos']) ?></h2>
+    <dl class="detail-list">
+        <dt>Documento</dt>
+        <dd><?= htmlspecialchars($usuario['documento']) ?></dd>
+        <dt>Correo</dt>
+        <dd><?= htmlspecialchars($usuario['correo']) ?></dd>
+        <dt>Rol</dt>
+        <dd><?= htmlspecialchars($usuario['rol']) ?></dd>
+        <dt>Club</dt>
+        <dd><?= htmlspecialchars($usuario['nombre_club'] ?? 'Sin club') ?></dd>
+        <dt>Estado</dt>
+        <dd><?= htmlspecialchars($usuario['estado']) ?></dd>
+        <dt>Fecha de registro</dt>
+        <dd><?= htmlspecialchars($usuario['fecha_registro']) ?></dd>
+    </dl>
+    <a class="btn" href="<?= htmlspecialchars(route('usuarios')) ?>">Volver al listado</a>
+</section>

--- a/cronoportes/core/Router.php
+++ b/cronoportes/core/Router.php
@@ -1,0 +1,64 @@
+<?php
+namespace Core;
+
+class Router
+{
+    private array $routes = [];
+
+    public function get(string $path, callable $action): void
+    {
+        $this->routes['GET'][$this->normalize($path)] = $action;
+    }
+
+    public function post(string $path, callable $action): void
+    {
+        $this->routes['POST'][$this->normalize($path)] = $action;
+    }
+
+    public function dispatch(string $method, string $uri): void
+    {
+        $path = parse_url($uri, PHP_URL_PATH) ?? '/';
+        $path = $this->normalize($path);
+
+        $routes = $this->routes[$method] ?? [];
+        $action = $routes[$path] ?? null;
+        $params = [];
+
+        if (!$action) {
+            foreach ($routes as $routePath => $routeAction) {
+                $pattern = $this->routeToPattern($routePath);
+                if (preg_match($pattern, $path, $matches)) {
+                    $action = $routeAction;
+                    array_shift($matches);
+                    $params = array_map(function ($value) {
+                        return ctype_digit($value) ? (int) $value : $value;
+                    }, $matches);
+                    break;
+                }
+            }
+        }
+
+        if (!$action) {
+            http_response_code(isset($this->routes[$method]) ? 404 : 405);
+            echo isset($this->routes[$method]) ? 'Ruta no encontrada' : 'Método no permitido';
+            return;
+        }
+
+        call_user_func_array($action, $params);
+    }
+
+    private function normalize(string $path): string
+    {
+        $path = '/' . trim($path, '/');
+        return $path === '//' ? '/' : ($path === '/' ? $path : rtrim($path, '/'));
+    }
+
+    private function routeToPattern(string $route): string
+    {
+        $pattern = preg_replace('#\{([^/]+)\}#', '([^/]+)', $route);
+        if ($pattern === null) {
+            $pattern = $route;
+        }
+        return '#^' . $pattern . '$#';
+    }
+}

--- a/cronoportes/database/cronodep.sql
+++ b/cronoportes/database/cronodep.sql
@@ -1,0 +1,109 @@
+-- 🔐 Base de datos inicial para CronoDep (SaaS)
+CREATE DATABASE IF NOT EXISTS cronodep;
+USE cronodep;
+
+-- Tabla de clubes (cada uno es una entidad SaaS)
+CREATE TABLE clubs (
+    id_club INT AUTO_INCREMENT PRIMARY KEY,
+    nombre_club VARCHAR(100) NOT NULL,
+    correo_contacto VARCHAR(100),
+    telefono_contacto VARCHAR(20),
+    direccion VARCHAR(150),
+    estado ENUM('activo', 'inactivo') DEFAULT 'activo',
+    fecha_registro DATETIME DEFAULT CURRENT_TIMESTAMP,
+    documento_operador VARCHAR(20),
+    fec_ult_actualizacion DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- Tabla de usuarios (todos los roles)
+CREATE TABLE usuarios (
+    id_usuario INT AUTO_INCREMENT PRIMARY KEY,
+    id_club INT,
+    nombres VARCHAR(100) NOT NULL,
+    apellidos VARCHAR(100) NOT NULL,
+    tipo_documento VARCHAR(20),
+    documento VARCHAR(20) UNIQUE NOT NULL,
+    correo VARCHAR(100) UNIQUE NOT NULL,
+    clave VARCHAR(255) NOT NULL,
+    rol ENUM('superadmin', 'admin', 'instructor', 'deportista', 'acudiente', 'tesorero') NOT NULL,
+    fecha_nacimiento DATE,
+    tipo_sangre VARCHAR(10),
+    celular VARCHAR(20),
+    estado ENUM('activo', 'inactivo') DEFAULT 'activo',
+    fecha_registro DATETIME DEFAULT CURRENT_TIMESTAMP,
+    documento_operador VARCHAR(20),
+    fec_ult_actualizacion DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    fec_ult_sesion DATETIME,
+    FOREIGN KEY (id_club) REFERENCES clubs(id_club) ON DELETE CASCADE
+);
+
+-- Tabla para relacionar acudientes con deportistas
+CREATE TABLE relacion_padres (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    id_acudiente INT,
+    id_deportista INT,
+    estado ENUM('activo', 'inactivo') DEFAULT 'activo',
+    fecha_registro DATETIME DEFAULT CURRENT_TIMESTAMP,
+    documento_operador VARCHAR(20),
+    fec_ult_actualizacion DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (id_acudiente) REFERENCES usuarios(id_usuario),
+    FOREIGN KEY (id_deportista) REFERENCES usuarios(id_usuario)
+);
+
+-- Tipos de entrenamiento (opcional si quieres manejarlos desde un listado fijo)
+CREATE TABLE tipos_entrenamiento (
+    id_tipo INT AUTO_INCREMENT PRIMARY KEY,
+    nombre_tipo VARCHAR(50) NOT NULL
+);
+
+-- Entrenamientos generales
+CREATE TABLE entrenamientos (
+    id_entrenamiento INT AUTO_INCREMENT PRIMARY KEY,
+    id_deportista INT,
+    id_instructor INT,
+    id_tipo INT,
+    lugar VARCHAR(100),
+    fecha DATE,
+    total_vueltas INT DEFAULT 0,
+    distancia_total FLOAT DEFAULT 0,
+    tiempo_total TIME,
+    observaciones TEXT,
+    estado ENUM('activo', 'inactivo') DEFAULT 'activo',
+    fecha_registro DATETIME DEFAULT CURRENT_TIMESTAMP,
+    documento_operador VARCHAR(20),
+    fec_ult_actualizacion DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (id_deportista) REFERENCES usuarios(id_usuario),
+    FOREIGN KEY (id_instructor) REFERENCES usuarios(id_usuario),
+    FOREIGN KEY (id_tipo) REFERENCES tipos_entrenamiento(id_tipo)
+);
+
+-- Vueltas por entrenamiento (solo si aplica: patinaje, ciclismo...)
+CREATE TABLE vueltas_entrenamiento (
+    id_vuelta INT AUTO_INCREMENT PRIMARY KEY,
+    id_entrenamiento INT,
+    numero_vuelta INT,
+    tiempo TIME,
+    distancia FLOAT,
+    estado ENUM('activo', 'inactivo') DEFAULT 'activo',
+    fecha_registro DATETIME DEFAULT CURRENT_TIMESTAMP,
+    documento_operador VARCHAR(20),
+    fec_ult_actualizacion DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (id_entrenamiento) REFERENCES entrenamientos(id_entrenamiento)
+);
+
+-- Control de pagos (mensualidades, matrículas, etc.)
+CREATE TABLE pagos (
+    id_pago INT AUTO_INCREMENT PRIMARY KEY,
+    id_deportista INT,
+    concepto ENUM('mensualidad', 'matricula', 'otro'),
+    descripcion VARCHAR(150),
+    valor DECIMAL(10,2),
+    fecha_pago DATE,
+    metodo_pago VARCHAR(50),
+    estado_pago ENUM('pagado', 'pendiente', 'mora') DEFAULT 'pendiente',
+    estado ENUM('activo', 'inactivo') DEFAULT 'activo',
+    fecha_registro DATETIME DEFAULT CURRENT_TIMESTAMP,
+    documento_operador VARCHAR(20),
+    fec_ult_actualizacion DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (id_deportista) REFERENCES usuarios(id_usuario)
+);

--- a/cronoportes/public/.htaccess
+++ b/cronoportes/public/.htaccess
@@ -1,0 +1,5 @@
+Options -Indexes
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^ index.php [QSA,L]

--- a/cronoportes/public/css/styles.css
+++ b/cronoportes/public/css/styles.css
@@ -44,6 +44,32 @@ body {
     margin-right: 0;
 }
 
+.app-header nav {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.logout-form {
+    margin: 0;
+    display: flex;
+}
+
+.logout-form button {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.8);
+    color: #ffffff;
+    padding: 0.35rem 0.75rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.logout-form button:hover,
+.logout-form button:focus {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+
 .app-content {
     padding: 2rem;
 }
@@ -117,6 +143,22 @@ table tr:last-child td {
     background-color: var(--secondary-color);
 }
 
+.btn-primary {
+    background-color: var(--primary-color);
+    color: #ffffff;
+    border: none;
+    padding: 0.65rem 1.5rem;
+    border-radius: 8px;
+    font-size: 1rem;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    background-color: var(--secondary-color);
+}
+
 .btn-secondary {
     background-color: #64748b;
 }
@@ -146,6 +188,71 @@ table tr:last-child td {
 .alert-error {
     background-color: rgba(198, 40, 40, 0.15);
     color: var(--error-color);
+}
+
+.auth-card {
+    max-width: 520px;
+    margin: 2rem auto;
+    background-color: var(--card-background);
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+}
+
+.auth-card h2 {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.help-text {
+    text-align: center;
+    font-size: 0.95rem;
+    color: #475569;
+}
+
+.auth-card .form-grid {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.auth-card fieldset {
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    padding: 1rem 1.5rem;
+}
+
+.auth-card legend {
+    padding: 0 0.5rem;
+    font-weight: 600;
+    color: var(--secondary-color);
+}
+
+.auth-card .form-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.auth-card .form-control input,
+.auth-card .form-control select,
+.auth-card .form-control textarea {
+    padding: 0.65rem 0.75rem;
+    border-radius: 6px;
+    border: 1px solid #cbd5e1;
+    font-size: 1rem;
+}
+
+.auth-card .form-control input:focus,
+.auth-card .form-control select:focus,
+.auth-card .form-control textarea:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px rgba(30, 136, 229, 0.15);
+}
+
+.auth-card .form-control .error {
+    color: var(--error-color);
+    font-size: 0.85rem;
 }
 
 .form-card {
@@ -215,6 +322,37 @@ table tr:last-child td {
     margin: 0;
 }
 
+.landing {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 2rem;
+    align-items: center;
+}
+
+.landing-hero h2 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+}
+
+.landing-hero p {
+    font-size: 1.05rem;
+    line-height: 1.6;
+    color: #475569;
+}
+
+.landing-actions {
+    margin-top: 1.5rem;
+}
+
+.landing-summary {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.landing-summary .card {
+    min-height: 160px;
+}
+
 @media (max-width: 768px) {
     .app-header {
         flex-direction: column;
@@ -229,6 +367,10 @@ table tr:last-child td {
     .form-actions {
         flex-direction: column;
         align-items: stretch;
+    }
+
+    .landing {
+        grid-template-columns: 1fr;
     }
 }
 

--- a/cronoportes/public/css/styles.css
+++ b/cronoportes/public/css/styles.css
@@ -1,0 +1,237 @@
+:root {
+    --primary-color: #1e88e5;
+    --secondary-color: #1565c0;
+    --background-color: #f4f6fb;
+    --text-color: #1f2933;
+    --card-background: #ffffff;
+    --error-color: #c62828;
+    --success-color: #2e7d32;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: var(--background-color);
+    color: var(--text-color);
+}
+
+.app-header {
+    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+    color: white;
+    padding: 1rem 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.app-header h1 {
+    margin: 0;
+}
+
+.app-header nav a {
+    color: white;
+    text-decoration: none;
+    margin-right: 1rem;
+    font-weight: 600;
+}
+
+.app-header nav a:last-child {
+    margin-right: 0;
+}
+
+.app-content {
+    padding: 2rem;
+}
+
+h2 {
+    color: var(--secondary-color);
+}
+
+.section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: var(--card-background);
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+table th,
+table td {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid #e2e8f0;
+    text-align: left;
+}
+
+table th {
+    background-color: #e3f2fd;
+    color: var(--secondary-color);
+    text-transform: uppercase;
+    font-size: 0.85rem;
+}
+
+table tr:last-child td {
+    border-bottom: none;
+}
+
+.card {
+    background-color: var(--card-background);
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+    margin-top: 1rem;
+}
+
+.btn {
+    display: inline-block;
+    background-color: var(--primary-color);
+    color: white;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.btn:hover,
+.btn:focus {
+    background-color: var(--secondary-color);
+}
+
+.btn-secondary {
+    background-color: #64748b;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+    background-color: #475569;
+}
+
+.btn-small {
+    padding: 0.35rem 0.75rem;
+    font-size: 0.85rem;
+}
+
+.alert {
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    font-weight: 600;
+}
+
+.alert-success {
+    background-color: rgba(46, 125, 50, 0.15);
+    color: var(--success-color);
+}
+
+.alert-error {
+    background-color: rgba(198, 40, 40, 0.15);
+    color: var(--error-color);
+}
+
+.form-card {
+    background-color: var(--card-background);
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.25rem;
+    margin-top: 1.5rem;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.form-group input,
+.form-group select {
+    padding: 0.65rem 0.75rem;
+    border-radius: 6px;
+    border: 1px solid #cbd5e1;
+    font-size: 1rem;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px rgba(30, 136, 229, 0.15);
+}
+
+.form-actions {
+    grid-column: 1 / -1;
+    display: flex;
+    gap: 0.75rem;
+}
+
+.form-error {
+    color: var(--error-color);
+    font-size: 0.85rem;
+}
+
+.detail-list {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: 0.75rem 1.5rem;
+    background-color: var(--card-background);
+    padding: 1.5rem;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.detail-list dt {
+    font-weight: 600;
+    color: var(--secondary-color);
+}
+
+.detail-list dd {
+    margin: 0;
+}
+
+@media (max-width: 768px) {
+    .app-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+    }
+
+    .detail-list {
+        grid-template-columns: 1fr;
+    }
+
+    .form-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}
+
+.app-header nav a.active {
+    text-decoration: underline;
+}

--- a/cronoportes/public/index.php
+++ b/cronoportes/public/index.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+session_start();
+
 spl_autoload_register(function ($class) {
     $prefixes = [
         'App\\' => __DIR__ . '/../app/',
@@ -25,7 +27,10 @@ $config = require __DIR__ . '/../app/config/config.php';
 
 define('BASE_URL', rtrim($config['app']['base_url'], '/') ?: '/');
 
-templateGlobals(['appName' => $config['app']['name'], 'baseUrl' => BASE_URL]);
+templateGlobals([
+    'appName' => $config['app']['name'],
+    'baseUrl' => BASE_URL,
+]);
 
 if (!function_exists('route')) {
     function route(string $path, array $query = []): string

--- a/cronoportes/public/index.php
+++ b/cronoportes/public/index.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+spl_autoload_register(function ($class) {
+    $prefixes = [
+        'App\\' => __DIR__ . '/../app/',
+        'Core\\' => __DIR__ . '/../core/',
+    ];
+
+    foreach ($prefixes as $prefix => $baseDir) {
+        $len = strlen($prefix);
+        if (strncmp($class, $prefix, $len) !== 0) {
+            continue;
+        }
+
+        $relativeClass = substr($class, $len);
+        $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
+        if (file_exists($file)) {
+            require_once $file;
+        }
+    }
+});
+
+$config = require __DIR__ . '/../app/config/config.php';
+
+define('BASE_URL', rtrim($config['app']['base_url'], '/') ?: '/');
+
+templateGlobals(['appName' => $config['app']['name'], 'baseUrl' => BASE_URL]);
+
+if (!function_exists('route')) {
+    function route(string $path, array $query = []): string
+    {
+        $trimmed = trim($path);
+        $normalized = ($trimmed === '' || $trimmed === '/') ? '/' : '/' . ltrim($trimmed, '/');
+        $baseUrl = $GLOBALS['baseUrl'] ?? '/';
+        $url = ($baseUrl === '/' || $baseUrl === '') ? $normalized : rtrim($baseUrl, '/') . $normalized;
+
+        if (!empty($query)) {
+            $url .= (str_contains($url, '?') ? '&' : '?') . http_build_query($query);
+        }
+
+        return $url;
+    }
+}
+
+\App\Models\Model::init($config['db']);
+
+$router = new \Core\Router();
+
+$routes = require __DIR__ . '/../routes/web.php';
+$routes($router);
+
+$router->dispatch($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);
+
+function templateGlobals(array $data): void
+{
+    foreach ($data as $key => $value) {
+        $GLOBALS[$key] = $value;
+    }
+}

--- a/cronoportes/public/js/app.js
+++ b/cronoportes/public/js/app.js
@@ -1,0 +1,19 @@
+(() => {
+    const navLinks = document.querySelectorAll('header nav a');
+    const currentPath = window.location.pathname.replace(/\/$/, '') || '/';
+
+    navLinks.forEach((link) => {
+        const href = link.getAttribute('href') || '';
+        const linkPath = href.replace(/\/$/, '') || '/';
+        if (linkPath === '/') {
+            if (currentPath === '/') {
+                link.classList.add('active');
+            }
+            return;
+        }
+
+        if (currentPath.startsWith(linkPath)) {
+            link.classList.add('active');
+        }
+    });
+})();

--- a/cronoportes/routes/web.php
+++ b/cronoportes/routes/web.php
@@ -1,0 +1,17 @@
+<?php
+use App\Controllers\HomeController;
+use App\Controllers\UsuarioController;
+use App\Controllers\ClubController;
+
+return function (Core\Router $router) {
+    $router->get('/', [new HomeController(), 'index']);
+
+    $router->get('/usuarios', [new UsuarioController(), 'index']);
+    $router->get('/usuarios/crear', [new UsuarioController(), 'create']);
+    $router->post('/usuarios', [new UsuarioController(), 'store']);
+    $router->get('/usuarios/{id}', [new UsuarioController(), 'show']);
+
+    $router->get('/clubs', [new ClubController(), 'index']);
+    $router->get('/clubs/crear', [new ClubController(), 'create']);
+    $router->post('/clubs', [new ClubController(), 'store']);
+};

--- a/cronoportes/routes/web.php
+++ b/cronoportes/routes/web.php
@@ -1,17 +1,31 @@
 <?php
+use App\Controllers\AuthController;
+use App\Controllers\ClubController;
 use App\Controllers\HomeController;
 use App\Controllers\UsuarioController;
-use App\Controllers\ClubController;
+use App\Middleware\AuthMiddleware;
 
 return function (Core\Router $router) {
-    $router->get('/', [new HomeController(), 'index']);
+    $home = new HomeController();
+    $auth = new AuthController();
+    $usuarios = new UsuarioController();
+    $clubs = new ClubController();
 
-    $router->get('/usuarios', [new UsuarioController(), 'index']);
-    $router->get('/usuarios/crear', [new UsuarioController(), 'create']);
-    $router->post('/usuarios', [new UsuarioController(), 'store']);
-    $router->get('/usuarios/{id}', [new UsuarioController(), 'show']);
+    $router->get('/', [$home, 'index']);
+    $router->get('/login', [$auth, 'login']);
+    $router->post('/login', [$auth, 'auth']);
+    $router->post('/logout', [$auth, 'logout']);
+    $router->get('/register-club', [$auth, 'registerClub']);
+    $router->post('/register-club', [$auth, 'storeClub']);
 
-    $router->get('/clubs', [new ClubController(), 'index']);
-    $router->get('/clubs/crear', [new ClubController(), 'create']);
-    $router->post('/clubs', [new ClubController(), 'store']);
+    $router->get('/dashboard', AuthMiddleware::requireAuth([$home, 'dashboard']));
+
+    $router->get('/usuarios', AuthMiddleware::handle(['superadmin', 'admin'], [$usuarios, 'index']));
+    $router->get('/usuarios/crear', AuthMiddleware::handle(['superadmin', 'admin'], [$usuarios, 'create']));
+    $router->post('/usuarios', AuthMiddleware::handle(['superadmin', 'admin'], [$usuarios, 'store']));
+    $router->get('/usuarios/{id}', AuthMiddleware::handle(['superadmin', 'admin'], [$usuarios, 'show']));
+
+    $router->get('/clubs', AuthMiddleware::handle(['superadmin', 'admin'], [$clubs, 'index']));
+    $router->get('/clubs/crear', AuthMiddleware::handle(['superadmin'], [$clubs, 'create']));
+    $router->post('/clubs', AuthMiddleware::handle(['superadmin'], [$clubs, 'store']));
 };


### PR DESCRIPTION
## Summary
- add POST routing support, reusable URL helpers, and a global `route()` utility for consistent links and redirects
- implement create/store actions with validation plus model helpers to register clubs and usuarios against the existing schema
- introduce registration forms, UI styling updates, and documentation for the new routes

## Testing
- `find cronoportes -name '*.php' -print0 | xargs -0 -n1 php -l`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69164e8c01b483279ea447592541b8c9)